### PR TITLE
Reduce flash wear on target device

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+ansible_remote_tmp: "/tmp/ansible"  # Reduce flash wear on target device
+
 openwrt_install_recommended_packages: yes
 
 openwrt_wait_for_connection: yes


### PR DESCRIPTION
By default, ansible stores its temporary files in `$HOME/.ansible/tmp`.
This causes many files to be created on target device's internal flash
memory on every ansible run (even if run with --check or if there are no
changes), wearing it unnecessarily.

This commit changes default remote_tmp location to a directory mounted
in RAM as tmpfs, so that the flash memory is not touched unless there is
actual change in device's configuration.