### PR TITLE
Fix for older OpenWRT versions & other fixes

### DIFF
--- a/library/openwrt_setup.sh
+++ b/library/openwrt_setup.sh
@@ -5,9 +5,10 @@
 NO_EXIT_JSON="1"
 
 add_ubus_fact() {
-    a=$(echo $1 | tr '/' '!')
+    local a=$(echo "$1" | tr '/' '!')
     set -- ${a//!/ }
-    local json="$($ubus call "$2" "$3" 2>/dev/null)" || return
+    ubus list "$2" > /dev/null 2>&1 || return
+    local json="$($ubus call "$2" "$3" 2>/dev/null)"
     echo -n "$seperator\"$1\":$json"
     seperator=","
 }

--- a/library/openwrt_setup.sh
+++ b/library/openwrt_setup.sh
@@ -5,7 +5,8 @@
 NO_EXIT_JSON="1"
 
 add_ubus_fact() {
-    set -- ${1//\// }
+    a=$(echo $1 | tr '/' '!')
+    set -- ${a//!/ }
     local json="$($ubus call "$2" "$3" 2>/dev/null)" || return
     echo -n "$seperator\"$1\":$json"
     seperator=","

--- a/library/openwrt_setup.sh
+++ b/library/openwrt_setup.sh
@@ -33,6 +33,7 @@ main() {
     dist_major="${dist_version%%.*}"
     json_set_namespace facts
     json_init
+    json_add_string ansible_hostname "$(cat /proc/sys/kernel/hostname)"
     json_add_string ansible_distribution "$dist"
     json_add_string ansible_distribution_major_version "$dist_major"
     json_add_string ansible_distribution_release "$dist_release"

--- a/library/openwrt_stat.sh
+++ b/library/openwrt_stat.sh
@@ -12,7 +12,7 @@ PARAMS="
 RESPONSE_VARS="
     charset/str
     checksum/str
-    ctime/float
+    ctime/int
     dev/int
     executable/bool
     exists/bool
@@ -32,7 +32,7 @@ RESPONSE_VARS="
     md5/str
     mime_type/str
     mode/str
-    mtime/float
+    mtime/int
     nlink/int
     pw_name/str
     readable/bool


### PR DESCRIPTION
1. This module does not work with Chaos Calmer (busybox v1.23.2) because *ash* for some reason does not understand escaped backslash. This commit does a workaround that works everywhere.

2. Unsupported *ubus* calls are handled wrong, fix this. This allows to gather facts on e.g. Attitude Adjustment 12.09 which does not have system/board/wireless namespaces.

3. Change type for mtime/ctime from float to int because older OpenWRT versions do not have `json_add_double` and `opkg` play does not work. Double is not needed for timestamps I think.

4. Add *ansible_hostname* to facts (does *cat /proc/sys/kernel/hostname*)