### PR TITLE
Fixing a deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,4 +13,4 @@
   import_tasks: packages.yml
   when:
     - "'openwrt' in group_names"
-    - openwrt_install_recommended_packages
+    - "openwrt_install_recommended_packages | bool"


### PR DESCRIPTION
With ansible 2.8 I was getting:
```
[DEPRECATION WARNING]: evaluating openwrt_install_recommended_packages as a bare variable, this behaviour will go away and you might need to add |bool to the 
expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
```
This change fixes this warning by using the filter to convert the variable to a boolean.