### PR TITLE
Fix path of installed ansible roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Currently, the following modules have been implemented:
  * uci (new)
  * wait\_for\_connection (implicit)
 
-To achieve all this, some monkey patching is involved (in case you wonder about the `filter\_plugins`).
+To achieve all this, some monkey patching is involved (in case you wonder about the `filter_plugins`).
 
 Requirements
 ------------
@@ -131,8 +131,8 @@ Playbook:
 
 Running the modules outside of a playbook is possible like this:
 
-    export ANSIBLE_LIBRARY=~/ansible-roles/gekmihesg.openwrt/library
-    export ANSIBLE_FILTER_PLUGINS=~/ansible-roles/gekmihesg.openwrt/filter_plugins
+    export ANSIBLE_LIBRARY=~/.ansible/roles/gekmihesg.openwrt/library
+    export ANSIBLE_FILTER_PLUGINS=~/.ansible/roles/gekmihesg.openwrt/filter_plugins
     ansible -i openwrt-hosts -m setup all
 
 License


### PR DESCRIPTION
If using `ansible-galaxy` to install roles, by default it downloads roles to the first writable directory in the default list of paths `~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles`.

See
* https://docs.ansible.com/ansible/2.6/reference_appendices/galaxy.html?highlight=galaxy#roles-path
* https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#setting-where-to-install-roles