### PR TITLE
Idempotence when using delete command

### DIFF
--- a/library/openwrt_uci.sh
+++ b/library/openwrt_uci.sh
@@ -288,7 +288,7 @@ main() {
         get)
             uci_get; exit 0;;
         delete)
-            final uci $command "$key${value:+=$value}";;
+            uci -q get "$key" 2>/dev/null && final uci $command "$key${value:+=$value}" || exit 0;;
         rename)
             final uci $command "$key=${name:-$value}";;
         revert)


### PR DESCRIPTION
Hi Markus,

I would like to suggest a change to the way uci delete is managed by module.
Currently when one attempts to delete the non-existing key - the execution fails with error (`/sbin/uci: Entry not found`), so in order to achieve idempotence with playbooks one needs to perform complex checks if entry that should be absent was already deleted in previous runs or not.

For example: if I would like to delete `network.wan6`, if I would code following:
```
- name: Delete wan6 interface
  uci:
    command: delete
    key: network.wan6
```
it would succeed on 1st run on "clean" OpenWrt installation, but will fail on subsequent runs as the `network.wan6` key will be already gone.

Surly this can be worked-around by example code:
```
- name: Check if wan6 exists
  uci:
    command: get
    key: network.wan6
    type: interface
  register: uci_network_wan6
  failed_when: false

- name: Delete wan6 interface
  uci:
    command: delete
    key: network.wan6
    type: interface
  when: uci_network_wan6.result == "interface"
```
while this makes playbooks unneccessary complicated. 

Simple change to library script will change the behavior to when delete command in uci is called for non-existent key - it will no fail, but succeed with no changes.