### PR TITLE
Fix variable typo, fix quotation in uci.py

### DIFF
--- a/library/openwrt_copy.sh
+++ b/library/openwrt_copy.sh
@@ -35,7 +35,7 @@ main() {
         tmp="$(dirname -- "$dest")"
         [ -d "$tmp" ] || {
             _IFS="$IFS"; IFS="/"; set -- $tmp; IFS="$_IFS"
-            tmp="$mode"; mode="$directoy_mode"
+            tmp="$mode"; mode="$directory_mode"
             local d
             local p=""
             for d; do

--- a/library/uci.py
+++ b/library/uci.py
@@ -175,7 +175,7 @@ section:
     description: section part of I(key)
     returned: when given
     type: string
-    sample: @wifi-iface[0]
+    sample: '@wifi-iface[0]'
 option:
     description: option part of I(key)
     returned: when given


### PR DESCRIPTION
`directoy` is clearly a typo.

`ansible-doc -M library uci` fails with a parse error due to invalid
YAML syntax. Add quotes.