### PR TITLE
Fix typo in example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Playbook:
         - gekmihesg.openwrt
       tasks:
         - name: copy openwrt image
-          command: "{{ openwrt_scp }}" image.bin {{ openwrt_user_host|quote }}:/tmp/sysupgrade.bin"
+          command: "{{ openwrt_scp }} image.bin {{ openwrt_user_host|quote }}:/tmp/sysupgrade.bin"
           delegate_to: localhost
         - name: start sysupgrade
           nohup:


### PR DESCRIPTION
Here's a fix for a small typo I found while running part of the example playbook.

Thanks for this project, it's very useful.