### PR TITLE
extend compatibility section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This role was tested successfully with:
  * LEDE 17.01
  * OpenWRT 18.06
  * OpenWRT 19.07
+ * OpenWRT 21.02
 
 Requirements
 ------------


### PR DESCRIPTION
I'm successfully using this repo on three openwrt 21.02.1 devices.
My playbook doesn't cover everything, but maybe someone can extend the modules successfully used.

This PR adds 21.02 to the compatibility section in the readme file.

- [x] command
- [x] copy
- [x] fetch (implicit)
- [x] file
- [x] lineinfile
- [x] nohup
- [x] opkg
- [x] ping
- [x] service
- [x] setup
- [x] shell (implicit)
- [x] slurp
- [x] stat
- [x] sysctl
- [x] template (implicit)
- [x] uci (new)
- [x] wait_for_connection (implicit)