### PR TITLE
Make the location of opkg-lists configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ openwrt_scp_if_ssh: True
 openwrt_ssh_transfer_method: "{{ 'smart' if openwrt_scp_if_ssh == 'smart' else openwrt_scp_if_ssh|ternary('scp', 'sftp') }}"
 openwrt_ssh_use_tty: no
 openwrt_remote_tmp: /tmp
+
+openwrt_remote_opkg_lists_dir: /tmp/opkg-lists

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,7 +1,7 @@
 ---
 - name: check whether opkg caches need update
   stat:
-    path: /tmp/opkg-lists
+    path: "{{ openwrt_remote_opkg_lists_dir }}"
   register: _opkg_lists
 
 - name: get current system time


### PR DESCRIPTION
On my OpenWRT devices opkg-lists is in /var