### PR TITLE
Add support for is_chroot fact

### DIFF
--- a/library/openwrt_setup.sh
+++ b/library/openwrt_setup.sh
@@ -38,6 +38,10 @@ main() {
     json_add_string ansible_distribution_release "$dist_release"
     json_add_string ansible_distribution_version "$dist_version"
     json_add_string ansible_os_family OpenWRT
+    json_add_boolean ansible_is_chroot "$([ -r /proc/1/root/. ] &&
+        { [ / -ef /proc/1/root/. ]; echo $?; } ||
+        { [ "$(ls -di / | awk '{print $1}')" -eq 2 ]; echo $?; }
+        )"
     dist_facts="$(json_dump)"
     json_cleanup
     json_set_namespace result


### PR DESCRIPTION
The `setup` module omits several facts that are set by Ansible's original `setup` module. One that I currently need is `is_chroot`.
This PR adds that fact.

The check is based on what Ansible does: Compare the inode number of `/` with that of `/proc/1/root/.`.
Ansible's original code also has a fallback for the case where `/proc` is not mounted or not accessible. I omitted that for simplicity.