### PR TITLE
fix: Verify the presence of opkg cache files for update

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -5,6 +5,7 @@
   register: _opkg_lists
 
 - name: verify there are actual cache files
+  when: _opkg_lists.stat.exists
   command:
     cmd: "find {{ openwrt_remote_opkg_lists_dir }} -type f"
   register: _opkg_list_files

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -4,6 +4,11 @@
     path: "{{ openwrt_remote_opkg_lists_dir }}"
   register: _opkg_lists
 
+- name: verify there are actual cache files
+  command:
+    cmd: "find {{ openwrt_remote_opkg_lists_dir }} -type f"
+  register: _opkg_list_files
+
 - name: get current system time
   command: date +%s
   register: _epoch
@@ -16,7 +21,9 @@
     name: opkg
     update_cache: true
   register: _update
-  when: not _opkg_lists.stat.exists or
+  when: not ( _opkg_lists.stat.exists and
+              _opkg_list_files.stdout is defined and
+              _opkg_list_files.stdout|length > 0) or
       _epoch.stdout|int - _opkg_lists.stat.mtime > 86400
   failed_when: not _opkg_lists.stat.exists and _update.failed
   changed_when: not _update.failed


### PR DESCRIPTION
When openwrt_remote_opkg_lists_dir is placed at /tmp/opkg-lists (the default), it is recreated on each boot. However, when any opkg command is run -- including e.g. `opkg list-installed` -- that directory is created and left empty.

On such a router, the first time an `opkg` command is run, the openwrt_remote_opkg_lists_dir is given mtime <= 86400 (at least for the next 24h), suggesting to the default ansible-openwrt's tasks that an `opkg update` has been issued recently when one has not. This seems to happen when an Ansible check-mode run is performed right after a router is booted.

Correct this problem by verifying that there are actual opkg cache files. We assume (perhaps incorrectly) that all of the opkg cache files were created at the same time during the most recent successful `opkg update` run, if there are any, meaning they all have dates roughly matching that of their openwrt_remote_opkg_lists_dir. As a result, we do not need to check the age of those files.

This commit fixes issue #55:
https://github.com/gekmihesg/ansible-openwrt/issues/55

Signed-off-by: Martin Kennedy <hurricos@gmail.com>