### PR TITLE
Add compatibility with ansible >= 2.19

### DIFF
--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -9,4 +9,4 @@
 - name: "install {{ item.value }} to provide {{ item.key }}"
   opkg:
     name: "{{ item.value }}"
-  when: _package.rc
+  when: _package.rc != 0

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -33,7 +33,7 @@
     base64: coreutils-base64
     md5sum: coreutils-md5sum
     sha1sum: coreutils-sha1sum
-  when: _openssl.rc
+  when: _openssl.rc != 0
 
 - name: avoid re-checking of packages
   set_fact:


### PR DESCRIPTION
In ansible 2.19 release return value of `ActionBse._configure_module` function was changed which leads to raising `Task failed: not enough values to unpack (expected 4, got 2)` error on any role task run.

This change add compatibility with ansible >= 2.19 and preserves compatibility with older versions.